### PR TITLE
Update MGH LL (Ba 0101-0150)

### DIFF
--- a/fb_systematik.org
+++ b/fb_systematik.org
@@ -187,13 +187,18 @@ CLOSED: [2022-07-27 Wed 11:19]
 ***** 0082 - xxxx Gesta pont. Roman. (Gesta pontificum Romanorum)
 ***** 0084 - 0089 Dt. Chron. (Scriptores qui vernacula lingua usi sunt) Deutsche Chroniken und andere Geschichtsbücher des Mittelalters
 ***** 0093 - 0095 Ldl (Libelli de lite imperatorum et pontificum)
-**** 0101 - 0150 MGH LL., Folio-Serie
-***** 0101 - 0105 LL, Folio
-***** 0106 - 0120 LL., Sectio I, Volkerecht
-***** 0121 - 0122 LL., Sectio II, Capitularia
-***** 0126 - 0134 LL., Sectio III, Concilia
-***** 0135 - 0147 LL., Sectio IV, Constitutiones
-***** 0148 - xxxx LL., Sectio V, Formulae
+**** DONE 0101 - 0150 MGH LL [Rechtstexte]
+***** 0101 - 0105 LL (Leges in Folio)
+***** 0106 - 0120 LL nat. Germ. (Leges nationum Germanicarum)
+***** 0121 - 0122 LL Capit. (Capitularia regum Francorum)
+***** 0121 - 0122 LL Capit. episc. (Capitula episcoporum)
+***** xxxx - xxxx LL Capit. N. S. (Capitularia regum Francorum, Nova series)
+***** 0126 - 0134 LL Conc. (Concilia)
+***** 0135 - 0147 LL Const. (Constitutiones et acta publica imperatorum et regum)
+***** 0148 - xxxx LL Formulae (Formulae Merowingici et Karolini aevi)
+***** xxxx - xxxx LL Ordines (Ordines de celebrando concilio)
+***** xxxx - xxxx LL Fontes iuris (Fonres iuris Germanici antiqui in usum scholarum separatim editi)
+***** xxxx - xxxx LL Fontes iuris N. S. (Fonres iuris Germanici antiqui, Nova series)
 **** 0151 - 0200 MGH DD
 ***** 0151 - xxxx DD. Mrov. (Folio)
 ***** 0152 - 0154 frei für DD Mer. in Quart


### PR DESCRIPTION
**Hier scheinen einige (neuere?) Unterreihen zu fehlen (5. Ebene) oder sind innerhalb der Systematik in anderen Oberkategorien einsortiert, vgl. Systematik der Bände auf dmgh.de**
 Ba - Allgemeine Quellensammlungen, Folio und Quart, innerhalb der MGH
**** 0101 - 0150 MGH LL [Rechtstexte]

**Bislang (gemäß Maschinenschrift)**
**** 0101 - 0150 MGH LL., Folio-Serie
***** 0101 - 0105 LL, Folio
***** 0106 - 0120 LL., Sectio I, Volkerecht
***** 0121 - 0122 LL., Sectio II, Capitularia
***** 0126 - 0134 LL., Sectio III, Concilia
***** 0135 - 0147 LL., Sectio IV, Constitutiones
***** 0148 - xxxx LL., Sectio V, Formulae

**Updates nach dmgh.de/leges.htm**
**** DONE 0101 - 0150 MGH LL [Rechtstexte]
***** 0101 - 0105 LL (Leges in Folio)
***** 0106 - 0120 LL nat. Germ. (Leges nationum Germanicarum)
***** 0121 - 0122 LL Capit. (Capitularia regum Francorum)
***** 0121 - 0122 LL Capit. episc. (Capitula episcoporum)
***** xxxx - xxxx LL Capit. N. S. (Capitularia regum Francorum, Nova series)
***** 0126 - 0134 LL Conc. (Concilia)
***** 0135 - 0147 LL Const. (Constitutiones et acta publica imperatorum et regum)
***** 0148 - xxxx LL Formulae (Formulae Merowingici et Karolini aevi)
***** xxxx - xxxx LL Ordines (Ordines de celebrando concilio)
***** xxxx - xxxx LL Fontes iuris (Fonres iuris Germanici antiqui in usum scholarum separatim editi)
***** xxxx - xxxx LL Fontes iuris N. S. (Fonres iuris Germanici antiqui, Nova series)
